### PR TITLE
Handle basename in location object

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,15 +41,15 @@ var PiwikTracker = function(opts) {
 	 * Adds a page view for the given location
 	 */
 	var track = function track (loc) {
-    var currentPath;
+		var currentPath;
 
-    if (loc.path) {
-      currentPath = loc.path;
-    } else if (loc.basename) {
-      currentPath = urljoin(loc.basename, loc.pathname, loc.search);
-    } else {
-      currentPath = urljoin(loc.pathname, loc.search);
-    }
+		if (loc.path) {
+		  currentPath = loc.path;
+		} else if (loc.basename) {
+		  currentPath = urljoin(loc.basename, loc.pathname, loc.search);
+		} else {
+		  currentPath = urljoin(loc.pathname, loc.search);
+		}
 
 		if (previousPath === currentPath) {
 			return;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var warning = require('warning');
+var urljoin = require('url-join');
 
 // api shim. used for serverside rendering and misconfigured tracker instances
 var apiShim = {
@@ -40,7 +41,15 @@ var PiwikTracker = function(opts) {
 	 * Adds a page view for the given location
 	 */
 	var track = function track (loc) {
-		var currentPath = loc.path || (loc.pathname + loc.search);
+    var currentPath;
+
+    if (loc.path) {
+      currentPath = loc.path;
+    } else if (loc.basename) {
+      currentPath = urljoin(loc.basename, loc.pathname, loc.search);
+    } else {
+      currentPath = urljoin(loc.pathname, loc.search);
+    }
 
 		if (previousPath === currentPath) {
 			return;

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     }
   ],
   "peerDependencies": {
-    "history": "^4.0.0"
+    "history": "^3.2.1"
   },
   "dependencies": {
+    "url-join": "^1.1.0",
     "warning": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   ],
   "peerDependencies": {
-    "history": "^3.2.1"
+    "history": "^3.0.0"
   },
   "dependencies": {
     "url-join": "^1.1.0",

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -301,6 +301,32 @@ describe('piwik-react-router client tests', function () {
     });
   });
 
+  it ('should correctly handle basename', () => {
+    const piwikReactRouter = testUtils.requireNoCache('../')({
+      url: 'foo.bar',
+      siteId: 1,
+    });
+
+    const unlistenFn = sinon.spy();
+    let listenStub = sinon.stub().returns(unlistenFn);
+
+    const history = {
+      listen: listenStub
+    };
+
+    piwikReactRouter.connectToHistory(history);
+    listenStub.getCall(0).args[0]({
+      basename: '/baseName',
+      pathname: '/foo/bar.html',
+      search: '?foo=bar'
+    });
+
+    assert.includeDeepMembers(window._paq, [
+      [ 'setCustomUrl', '/baseName/foo/bar.html?foo=bar' ],
+      [ 'trackPageView' ]
+    ]);
+  });
+
   it ('should correctly ignore the second call if the location did not change', () => {
     const piwikReactRouter = testUtils.requireNoCache('../')({
       url: 'foo.bar',


### PR DESCRIPTION
react-router supports useBasename which sets basename property on the location object. It's value should be used to construct the full path before sending data to Piwik. Also I have downgraded the history peerDependency version to be in sync with react-router, since react-router doesn't support version 4.