### PR TITLE
Updated dependencies to allow history 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   ],
   "peerDependencies": {
-    "history": "^3.0.0"
+    "history": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "url-join": "^1.1.0",


### PR DESCRIPTION
It seems as if this package does still work fine with `react-router@^4.0.0` + `history@4.0.0`
At least I haven't experienced any problems yet with a piwik-react-router+redux+react-router-redux... setup.

As the peerDependency is locked to `^3.0.0`, it breaks `npm install` for me. That why I've created this trivial PR.

There still might be incompatibilities. I haven't thoroughly tested the package against history v4