### PR TITLE
Optionally disable injection of piwik script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ see [http://davidwalsh.name/track-errors-google-analytics](http://davidwalsh.nam
 By enabling `ignoreInitialVisit` it connects to the history without tracking the initial visit.
 
 
+### injectScript: `true`
+
+By disabling `injectScript` the piwik.js script will not be injected automatically to allow a separate loading.
+
+
 ## API
 
 ### track (Location location)

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ var PiwikTracker = function(opts) {
 	opts.enableLinkTracking = ((opts.enableLinkTracking !== undefined) ? opts.enableLinkTracking : true);
 	opts.updateDocumentTitle = ((opts.updateDocumentTitle !== undefined) ? opts.updateDocumentTitle : true);
 	opts.ignoreInitialVisit = ((opts.ignoreInitialVisit !== undefined) ? opts.ignoreInitialVisit : false);
+	opts.injectScript = ((opts.injectScript !== undefined) ? opts.injectScript : true);
 
   if (!opts.url || !opts.siteId) {
 		// Only return warning if this is not in the test environment as it can break the Tests/CI.
@@ -149,8 +150,10 @@ var PiwikTracker = function(opts) {
 			push(['enableLinkTracking']);
 		}
 
-		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=true; g.src=u+'piwik.js';
-		s.parentNode.insertBefore(g,s);
+		if (opts.injectScript) {
+			var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=true; g.src=u+'piwik.js';
+			s.parentNode.insertBefore(g,s);
+		}
 	})();
 
 	// return api

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -365,6 +365,38 @@ describe('piwik-react-router client tests', function () {
     });
   });
 
+  describe('should correctly inject piwik script', () => {
+    it ('should inject piwik.js if opts.injectScript is enabled', () => {
+      const piwikReactRouter = testUtils.requireNoCache('../')({
+        url: 'foo.bar',
+        siteId: 1,
+        injectScript: true
+      });
+
+      var allScripts = [].slice.call(window.document.scripts);
+      var piwikScripts = allScripts.filter((script) => {
+        return script.src.indexOf('piwik.js') !== -1;
+      });
+
+      assert.isTrue(piwikScripts.length >= 1);
+    });
+
+    it ('should not inject piwik.js if opts.injectScript is disabled', () => {
+      const piwikReactRouter = testUtils.requireNoCache('../')({
+        url: 'foo.bar',
+        siteId: 1,
+        injectScript: false
+      });
+
+      var allScripts = [].slice.call(window.document.scripts);
+      var piwikScripts = allScripts.filter((script) => {
+        return script.src.indexOf('piwik.js') !== -1;
+      });
+
+      assert.isTrue(piwikScripts.length === 0);
+    });
+  });
+
   it ('should correctly handle basename', () => {
     const piwikReactRouter = testUtils.requireNoCache('../')({
       url: 'foo.bar',


### PR DESCRIPTION
Added an option to disable the injection of the piwik.js script into DOM.
Also added tests for the option. 
**Default:** Injection enabled.

**CAUSES:** 

We need to load the script separately to:
* prevent uncontrollable side effects
* prevent multiple loading if script already exists
* make loading of the script configurable
