### PR TITLE
Add option for setting client/server tracker names (piwik.js, piwik.php)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ _Starting with v2.0 react-router won't provide a default history. [Why?](https:/
 var PiwikReactRouter = require('piwik-react-router');
 
 var piwik = PiwikReactRouter({
-	url			: 'your-piwik-installation.com',
-	siteId		: 1
+	url: 'your-piwik-installation.com',
+	siteId: 1
 });
 
 <Router history={piwik.connectToHistory(history)}>
@@ -75,6 +75,16 @@ see [http://davidwalsh.name/track-errors-google-analytics](http://davidwalsh.nam
 ### ignoreInitialVisit: `false`
 
 By enabling `ignoreInitialVisit` it connects to the history without tracking the initial visit.
+
+
+### clientTrackerName: `'piwik.js'`
+
+The name of the `piwik.js` static resource on the Piwik server. Set this option if the Piwik instance uses a different name.
+
+
+### serverTrackerName: `'piwik.php'`
+
+The name of the `piwik.php` script on the Piwik server. Set this option if the Piwik instance uses a different name.
 
 
 ## API

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ var PiwikTracker = function(opts) {
 	opts.enableLinkTracking = ((opts.enableLinkTracking !== undefined) ? opts.enableLinkTracking : true);
 	opts.updateDocumentTitle = ((opts.updateDocumentTitle !== undefined) ? opts.updateDocumentTitle : true);
 	opts.ignoreInitialVisit = ((opts.ignoreInitialVisit !== undefined) ? opts.ignoreInitialVisit : false);
+	opts.clientTrackerName = ((opts.clientTrackerName !== undefined) ? opts.clientTrackerName : 'piwik.js');
+	opts.serverTrackerName = ((opts.serverTrackerName !== undefined) ? opts.serverTrackerName : 'piwik.php');
 
   if (!opts.url || !opts.siteId) {
 		// Only return warning if this is not in the test environment as it can break the Tests/CI.
@@ -139,7 +141,7 @@ var PiwikTracker = function(opts) {
     }
 
 		push(['setSiteId', opts.siteId]);
-		push(['setTrackerUrl', u+'piwik.php']);
+		push(['setTrackerUrl', u+opts.serverTrackerName]);
 
 		if (opts.userId) {
 			push(['setUserId', opts.userId]);
@@ -149,7 +151,7 @@ var PiwikTracker = function(opts) {
 			push(['enableLinkTracking']);
 		}
 
-		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=true; g.src=u+'piwik.js';
+		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=true; g.src=u+opts.clientTrackerName;
 		s.parentNode.insertBefore(g,s);
 	})();
 

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -83,6 +83,20 @@ describe('piwik-react-router client tests', function () {
     ]);
   });
 
+  it ('should correctly use client and server tracker name defaults', () => {
+    const piwikReactRouter = testUtils.requireNoCache('../')({
+      url: 'foo.bar',
+      siteId: 1
+    });
+
+    assert.sameDeepMembers(window._paq, [
+      [ 'setSiteId', 1 ],
+      [ 'setTrackerUrl', 'http://foo.bar/piwik.php' ],
+      [ 'enableLinkTracking' ]
+    ]);
+    assert.strictEqual(window.document.querySelector('script').src, 'http://foo.bar/piwik.js');
+  });
+
   describe ('use https protocol', () => {
     before(() => {
       this.jsdom();
@@ -113,6 +127,29 @@ describe('piwik-react-router client tests', function () {
         [ 'setTrackerUrl', 'https://foo.bar/piwik.php' ],
         [ 'enableLinkTracking' ]
       ]);
+    });
+  });
+
+  describe ('should allow overriding piwik.js and piwik.php names', () => {
+    before(() => {
+      this.jsdom();
+      this.jsdom = require('jsdom-global')(jsdomBody, {
+        url: 'https://foo.bar'
+      });
+    });
+
+    it('should use specified names for piwik.js and piwik.php', () => {
+      const piwikReactRouter = testUtils.requireNoCache('../')({
+        url: 'foo.bar',
+        siteId: 1,
+        clientTrackerName: 'foo.js',
+        serverTrackerName: 'bar.php'
+      });
+
+      assert.includeDeepMembers(window._paq, [
+        ['setTrackerUrl', 'https://foo.bar/bar.php'],
+      ]);
+      assert.strictEqual(window.document.querySelector('script').src, 'https://foo.bar/foo.js');
     });
   });
 


### PR DESCRIPTION
Add `clientTrackerName` and `serverTrackerName` fields to `PiwikReactRouter` options to allow overriding default `piwik.js` and `piwik.php` names used by this client.

(These names are pretty lengthy, let me know if you have a better and/or more concise variable name)

Fixes #34.