### PR TITLE
Allow setting of custom error tracking handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ By enabling this option occurring javascript errors will be tracked as a `JavaSc
 see [http://davidwalsh.name/track-errors-google-analytics](http://davidwalsh.name/track-errors-google-analytics) for further details
 
 
+## trackErrorHandler: [default error handler]
+
+Set a custom error handler for javascript errors, allowing custom formatting of events published when an error occurs.
+
+see [Tracking Events](http://piwik.org/docs/event-tracking/#tracking-events) for further details
+
 ### ignoreInitialVisit: `false`
 
 By enabling `ignoreInitialVisit` it connects to the history without tracking the initial visit.
@@ -113,6 +119,8 @@ Pushes the specified args to the Piwik tracker the same way as you're using the 
 ### trackError (error, [eventName])
 
 Tracks the given error as a new [Piwik Event](http://piwik.org/docs/event-tracking/#tracking-events) for the given event name. If you don't specify any name here it will fallback to `JavaScript Error`.
+
+The handler is overriden if the `trackErrorHandler` option is set.
 
 
 ### connectToHistory(history, [modifier])

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var PiwikTracker = function(opts) {
 
   opts = opts || {};
 	opts.trackErrors = ((opts.trackErrors !== undefined) ? opts.trackErrors : false);
+	opts.trackErrorHandler = ((opts.trackErrorHandler !== undefined) ? opts.trackErrorHandler : trackError);
 	opts.enableLinkTracking = ((opts.enableLinkTracking !== undefined) ? opts.enableLinkTracking : true);
 	opts.updateDocumentTitle = ((opts.updateDocumentTitle !== undefined) ? opts.updateDocumentTitle : true);
 	opts.ignoreInitialVisit = ((opts.ignoreInitialVisit !== undefined) ? opts.ignoreInitialVisit : false);
@@ -83,7 +84,7 @@ var PiwikTracker = function(opts) {
 	 *
 	 * @see http://davidwalsh.name/track-errors-google-analytics
 	 */
-	var trackError = function trackError (e, eventName) {
+	function trackError (e, eventName) {
 		eventName = eventName || 'JavaScript Error';
 
 		push([
@@ -136,13 +137,13 @@ var PiwikTracker = function(opts) {
 
 	if (opts.trackErrors) {
 		if (window.addEventListener) {
-			window.addEventListener('error', trackError, false);
+			window.addEventListener('error', opts.trackErrorHandler, false);
 		}
 		else if (window.attachEvent) {
-			window.attachEvent('onerror', trackError);
+			window.attachEvent('onerror', opts.trackErrorHandler);
 		}
 		else {
-			window.onerror = trackError;
+			window.onerror = opts.trackErrorHandler;
 		}
 	}
 
@@ -176,7 +177,7 @@ var PiwikTracker = function(opts) {
     _isShim: false,
 		track: track,
 		push: push,
-		trackError: trackError,
+		trackError: opts.trackErrorHandler,
 		connectToHistory: connectToHistory,
 		disconnectFromHistory: disconnectFromHistory
 	};

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -276,7 +276,22 @@ describe('piwik-react-router client tests', function () {
       assert.strictEqual(window.onerror, piwikReactRouter.trackError);
     });
 
+    it('should use a custom error handler if provided', () => {
+      window.addEventListener = undefined;
+      window.attachEvent = undefined;
 
+      const trackErrorHandler = sinon.spy();
+
+      const piwikReactRouter = testUtils.requireNoCache('../')({
+        url: 'foo.bar',
+        siteId: 1,
+        trackErrors: true,
+        trackErrorHandler,
+      });
+
+      assert.strictEqual(window.onerror, trackErrorHandler);
+      assert.strictEqual(piwikReactRouter.trackError, trackErrorHandler);
+    });
   });
 
   describe('history', () => {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -276,7 +276,7 @@ describe('piwik-react-router client tests', function () {
       assert.strictEqual(window.onerror, piwikReactRouter.trackError);
     });
 
-    it('should use a custom error handler if provided', () => {
+    it('should use a custom error handler if provided', function() {
       window.addEventListener = undefined;
       window.attachEvent = undefined;
 
@@ -286,7 +286,7 @@ describe('piwik-react-router client tests', function () {
         url: 'foo.bar',
         siteId: 1,
         trackErrors: true,
-        trackErrorHandler,
+        trackErrorHandler: trackErrorHandler
       });
 
       assert.strictEqual(window.onerror, trackErrorHandler);


### PR DESCRIPTION
* Add support for custom error handler for JS errors, called with (`event`, `eventName?`)
* Document changes
* Add test