### PR TITLE
Add a public API to set user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Adds a page view from a history [Location](https://github.com/rackt/history/blob
 Pushes the specified args to the Piwik tracker the same way as you're using the `_paq.push(args);` directly. You can use this method as the low-level api to call methods from the [Piwik API](http://developer.piwik.org/api-reference/tracking-javascript#list-of-all-methods-available-in-the-tracking-api), [track events](http://piwik.org/docs/event-tracking/#tracking-events) or call [custom functions](http://developer.piwik.org/guides/tracking-javascript-guide).
 
 
+### setUserId (userId)
+
+Sets the specified user id to the Piwik tracker after `PiwikReactRouter` has been initialized. It wraps around the `'setUserId'` method of Piwik [User ID](https://developer.piwik.org/guides/tracking-javascript-guide#user-id)
+
+
 ### trackError (error, [eventName])
 
 Tracks the given error as a new [Piwik Event](http://piwik.org/docs/event-tracking/#tracking-events) for the given event name. If you don't specify any name here it will fallback to `JavaScript Error`.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var apiShim = {
   _isShim: true,
 	track: function () {},
 	push: function (args) {},
+	setUserId: function (userId) {},
 	trackError: function (e) {},
 	connectToHistory: function (history, modifier) { return history; },
 	disconnectFromHistory: function () {}
@@ -77,6 +78,16 @@ var PiwikTracker = function(opts) {
 	 */
 	var push = function push (args) {
 		window._paq.push(args);
+	};
+
+  /**
+	 * Sets a user ID to the piwik tracker.
+	 * This method can be used after PiwikReactRouter is instantiated, for example after a user has logged in
+	 *
+	 * @see https://developer.piwik.org/guides/tracking-javascript-guide#user-id
+	 */
+	var setUserId = function setUserId (userId) {
+		window._paq.push(['setUserId', userId])
 	};
 
 	/**
@@ -177,6 +188,7 @@ var PiwikTracker = function(opts) {
     _isShim: false,
 		track: track,
 		push: push,
+		setUserId, setUserId,
 		trackError: opts.trackErrorHandler,
 		connectToHistory: connectToHistory,
 		disconnectFromHistory: disconnectFromHistory

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ var PiwikTracker = function(opts) {
 		push(['setTrackerUrl', u+opts.serverTrackerName]);
 
 		if (opts.userId) {
-			push(['setUserId', opts.userId]);
+			setUserId(opts.userId);
 		}
 
 		if (opts.enableLinkTracking) {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -55,7 +55,7 @@ describe('piwik-react-router client tests', function () {
     ]);
   });
 
-  it ('should correctly push the userId', () => {
+  it ('should correctly push the userId on instantiation', () => {
     const piwikReactRouter = testUtils.requireNoCache('../')({
       url: 'foo.bar',
       siteId: 1,
@@ -207,6 +207,25 @@ describe('piwik-react-router client tests', function () {
       assert.isFalse(warningSpy.called);
     });
 
+  });
+
+  describe('setUserId', () => {
+    it('should add user id to _paq', () => {
+      const piwikReactRouter = testUtils.requireNoCache('../')({
+        url: 'foo.bar',
+        siteId: 1
+      });
+
+      const userId = 'user@email.com';
+      piwikReactRouter.setUserId(userId);
+
+      assert.includeDeepMembers(window._paq, [
+        [
+          'setUserId',
+          'user@email.com'
+        ]
+      ]);
+    });
   });
 
   //it ('should correctly warn')

--- a/test/utils.js
+++ b/test/utils.js
@@ -13,6 +13,7 @@ const requireNoCache = function (filePath, opts) {
 const API_METHOD_NAMES = [
   'track',
   'push',
+	'setUserId',
   'trackError',
   'connectToHistory',
   'disconnectFromHistory'


### PR DESCRIPTION
Adding a public API to set user ID after instantiating `PiwikReactRouter`.

The method `setUserId()` can be used instead of having to use the low level `push()` API with a literal `'setUserId'` method name.