### PR TITLE
Add support for optional trackers by using addTracker method

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ The name of the `piwik.js` static resource on the Piwik server. Set this option 
 
 The name of the `piwik.php` script on the Piwik server. Set this option if the Piwik instance uses a different name.
 
+### optionalTrackers: []
+
+Set a comma delimited list of Matomo servers urls for addTracker.  
+
+- The list of `url`s must match the order of urls in `optionalTrackersWebsiteId`.
+- e.g. [https://asdf.bar/piwik.php, https://qwerty.bar/piwik.php]
+
+By using this together with `optionalTrackersWebsiteId` you can track your analytics data into more than just one Matomo server or into multiple websites on the same Matomo server. See [Multiple Matomo trackers](https://developer.matomo.org/guides/tracking-javascript-guide#multiple-piwik-trackers)
+
+### optionalTrackersWebsiteId: []
+
+Set a comma delimited list of Matomo `siteId` for addTracker. Used together with `optionalTrackers`. 
+
+- The list of `siteId`s must match the order of urls in `optionalTrackers`.
+- e.g. [1, 2]
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,8 @@ var PiwikTracker = function(opts) {
 	opts.injectScript = ((opts.injectScript !== undefined) ? opts.injectScript : true);
 	opts.clientTrackerName = ((opts.clientTrackerName !== undefined) ? opts.clientTrackerName : 'piwik.js');
 	opts.serverTrackerName = ((opts.serverTrackerName !== undefined) ? opts.serverTrackerName : 'piwik.php');
+	opts.optionalTrackers = ((opts.optionalTrackers !== undefined) ? opts.optionalTrackers : []);
+	opts.optionalTrackersWebsiteId = ((opts.optionalTrackersWebsiteId !== undefined) ? opts.optionalTrackersWebsiteId : []);
 
 	var alreadyInitialized = piwikIsAlreadyInitialized();
 
@@ -219,6 +221,12 @@ var PiwikTracker = function(opts) {
 
 			push(['setSiteId', opts.siteId]);
 			push(['setTrackerUrl', u + opts.serverTrackerName]);
+
+			if (opts.optionalTrackers && opts.optionalTrackersWebsiteId && !alreadyInitialized) {
+				for (var i in opts.optionalTrackers) {
+					push(['addTracker', opts.optionalTrackers[i], opts.optionalTrackersWebsiteId[i]]);
+				}
+			}
 		}
 
 		if (opts.userId) {

--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ var PiwikTracker = function(opts) {
 			push(['setSiteId', opts.siteId]);
 			push(['setTrackerUrl', u + opts.serverTrackerName]);
 
-			if (opts.optionalTrackers && opts.optionalTrackersWebsiteId && !alreadyInitialized) {
+			if (opts.optionalTrackers.length && opts.optionalTrackersWebsiteId.length ) {
 				for (var i in opts.optionalTrackers) {
 					push(['addTracker', opts.optionalTrackers[i], opts.optionalTrackersWebsiteId[i]]);
 				}

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -55,6 +55,57 @@ describe('piwik-react-router client tests', function () {
     ]);
   });
 
+  it ('should correctly push the addTracker to the _paq array on instantiation if optionalTrackers and optionalTrackersWebsiteId are given', () => {
+    const piwikReactRouter = testUtils.requireNoCache('../')({
+      url: 'foo.bar',
+      siteId: 1,
+      enableLinkTracking: true,
+      optionalTrackers: ['http://bar.bar/piwik.php'],
+      optionalTrackersWebsiteId: [2]
+    });
+
+    assert.sameDeepMembers(window._paq, [
+      [ 'setSiteId', 1 ],
+      [ 'setTrackerUrl', 'http://foo.bar/piwik.php' ],
+      [ 'enableLinkTracking' ],
+      [ 'addTracker', 'http://bar.bar/piwik.php', 2]
+    ]);
+  });
+
+  it ('should correctly push multiple addTrackers to the _paq array on instantiation if optionalTrackers and optionalTrackersWebsiteId are given with multiple values', () => {
+    const piwikReactRouter = testUtils.requireNoCache('../')({
+      url: 'foo.bar',
+      siteId: 1,
+      enableLinkTracking: true,
+      optionalTrackers: ['http://bar.bar/piwik.php', 'http://qwerty.bar/piwik.php'],
+      optionalTrackersWebsiteId: [1, 2]
+    });
+
+    assert.sameDeepMembers(window._paq, [
+      [ 'setSiteId', 1 ],
+      [ 'setTrackerUrl', 'http://foo.bar/piwik.php' ],
+      [ 'enableLinkTracking' ],
+      [ 'addTracker', 'http://bar.bar/piwik.php', 1],
+      [ 'addTracker', 'http://qwerty.bar/piwik.php', 2]
+    ]);
+  });
+
+  it ('should not push addTracker to the _paq array on instantiation if optionalTrackers and optionalTrackersWebsiteId are not given', () => {
+    const piwikReactRouter = testUtils.requireNoCache('../')({
+      url: 'foo.bar',
+      siteId: 1,
+      enableLinkTracking: true,
+      optionalTrackers: [],
+      optionalTrackersWebsiteId: []
+    });
+
+    assert.sameDeepMembers(window._paq, [
+      [ 'setSiteId', 1 ],
+      [ 'setTrackerUrl', 'http://foo.bar/piwik.php' ],
+      [ 'enableLinkTracking' ]
+    ]);
+  });
+
   it ('should correctly push the userId on instantiation', () => {
     const piwikReactRouter = testUtils.requireNoCache('../')({
       url: 'foo.bar',


### PR DESCRIPTION
In some cases there's need to track analytics data into more than just one Matomo server or into multiple websites on the same Matomo server. It can be achieved with several ways and one is to use addTracker method. See [documentation](https://developer.matomo.org/guides/tracking-javascript-guide#collect-your-analytics-data-into-two-or-more-piwik-servers).