### PR TITLE
Auto inject script

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,11 +233,18 @@ var PiwikTracker = function(opts) {
 			var d=document;
 			var g=d.createElement('script');
 			var s=d.getElementsByTagName('script')[0];
+
 			g.type='text/javascript';
 			g.defer=true;
 			g.async=true;
 			g.src=u+opts.clientTrackerName;
-			s.parentNode.insertBefore(g, s);
+			
+			if (s) {
+				s.parentNode.insertBefore(g,s)
+			} else {
+				var body=d.getElementsByTagName('body')[0];
+				body.appendChild(g);
+			}
 		}
 	})();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "piwik-react-router",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Piwik analytics component for react-router",
   "keywords": [
     "react",

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -7,11 +7,7 @@ describe('piwik-react-router client tests', function () {
   let jsdomBody;
 
   beforeEach(() => {
-    // piwiks tracking client doesn't properly adds the script tag to jsdom or the other way around.
-    // As i won't modify the piwik loading script the easiest was to provide this hacky script tag.
-    // Dirty – i know ;)
-    jsdomBody = '<script></script>';
-
+    jsdomBody = '';
     this.jsdom = require('jsdom-global')(jsdomBody, {
       url: 'http://foo.bar'
     });
@@ -580,6 +576,9 @@ describe('piwik-react-router client tests', function () {
 
     it ('should warn about a missing siteId if opts.injectScript is disabled and the external piwik script is not properly initialized', () => {
       let warningSpy = sinon.spy();
+      // add script tag for piwik initialization to find
+      let emptyScriptTag = document.createElement('script');
+      document.getElementsByTagName('body')[0].appendChild(emptyScriptTag);
 
       // instantiating piwik
       (function() {
@@ -603,6 +602,9 @@ describe('piwik-react-router client tests', function () {
 
     it ('should not warn about a missing siteId if opts.injectScript is disabled and the external piwik script is initialized', () => {
       let warningSpy = sinon.spy();
+      // add script tag for piwik initialization to find
+      let emptyScriptTag = document.createElement('script');
+      document.getElementsByTagName('body')[0].appendChild(emptyScriptTag);
 
       // instantiating piwik
       (function() {
@@ -627,6 +629,9 @@ describe('piwik-react-router client tests', function () {
     it ('should not warn about a missing siteId if opts.injectScript is disabled and the external piwik script has replaced _paq with the TrackerProxy', () => {
       let warningSpy = sinon.spy();
       let trackerProxySpy = sinon.spy();
+      // add script tag for piwik initialization to find
+      let emptyScriptTag = document.createElement('script');
+      document.getElementsByTagName('body')[0].appendChild(emptyScriptTag);
 
       // instantiating piwik
       (function() {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -562,6 +562,24 @@ describe('piwik-react-router client tests', function () {
       assert.isTrue(piwikScripts.length === 0);
     });
 
+    it ('should inject piwik.js if another script object is already present', () => {
+      let emptyScriptTag = document.createElement('script');
+      document.getElementsByTagName('head')[0].appendChild(emptyScriptTag);
+
+      const piwikReactRouter = testUtils.requireNoCache('../')({
+        url: 'foo.bar',
+        siteId: 1,
+        injectScript: true
+      });
+
+      var allScripts = [].slice.call(window.document.scripts);
+      var piwikScripts = allScripts.filter((script) => {
+        return script.src.indexOf('piwik.js') !== -1;
+      });
+
+      assert.isTrue(piwikScripts.length >= 1);
+    });
+
     it ('should warn about a missing siteId if opts.injectScript is disabled and the external piwik script is not initialized', () => {
       let warningSpy = sinon.spy();
       const piwikReactRouter = testUtils.requireNoCache('../', {


### PR DESCRIPTION
As discussed in #48, injection fails if the document does not contain a script tag.
(For example in test suites with jsdom)

This simply checks for presence of a script tag and appends a new script tag if none is found.