### PR TITLE
Add support for using with react-router v3 which uses history v3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,8 +179,15 @@ var PiwikTracker = function(opts) {
 						applyModifierAndTrackLocation(modifier, location);
 		});
 
-				if (!opts.ignoreInitialVisit && history.location) {
-						applyModifierAndTrackLocation(modifier, history.location);
+				var initialLocation
+				if (history.location) {
+					initialLocation = history.location
+				} else if (typeof history.getCurrentLocation === 'function') {
+					initialLocation = history.getCurrentLocation()
+				}
+
+				if (!opts.ignoreInitialVisit && initialLocation) {
+					applyModifierAndTrackLocation(modifier, initialLocation);
 				}
 
 		return history;

--- a/index.js
+++ b/index.js
@@ -179,11 +179,11 @@ var PiwikTracker = function(opts) {
 						applyModifierAndTrackLocation(modifier, location);
 		});
 
-				var initialLocation
+				var initialLocation;
 				if (history.location) {
-					initialLocation = history.location
+					initialLocation = history.location;
 				} else if (typeof history.getCurrentLocation === 'function') {
-					initialLocation = history.getCurrentLocation()
+					initialLocation = history.getCurrentLocation();
 				}
 
 				if (!opts.ignoreInitialVisit && initialLocation) {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -510,6 +510,39 @@ describe('piwik-react-router client tests', function () {
       ]);
     });
 
+    it ('should correctly track the initial visit if opts.ignoreInitialVisit is disabled with React Router v3', ()  => {
+      const piwikReactRouter = testUtils.requireNoCache('../')({
+        url: 'foo.bar',
+        siteId: 1,
+      });
+
+      const unlistenFn = sinon.spy();
+      let listenStub = sinon.stub().returns(unlistenFn);
+
+      var object = { getCurrentLocation: function() {
+        return {
+          pathname: '/foo/bar.html',
+          search: '?foo=bar'
+        };
+      }}
+
+      const locationFn = sinon.spy(object, "getCurrentLocation");
+
+      const history = {
+        listen: listenStub,
+        getCurrentLocation: locationFn
+      };
+
+      piwikReactRouter.connectToHistory(history);
+
+      assert.includeDeepMembers(window._paq, [
+        [ 'setCustomUrl', '/foo/bar.html?foo=bar' ],
+        [ 'trackPageView' ]
+      ]);
+
+      assert.isTrue(locationFn.called);
+    });
+
     it ('should correctly ignore the initial visit if the appropriate option is enabled', () => {
       const piwikReactRouter = testUtils.requireNoCache('../')({
         url: 'foo.bar',


### PR DESCRIPTION
The first tracking fails as it tries to look for page history.location which was added in history v4 and replaced history.getCurrentLocation() function in history v3.